### PR TITLE
allow the use of hard-tabs as whitespace

### DIFF
--- a/src/zz.pest
+++ b/src/zz.pest
@@ -1,4 +1,4 @@
-WHITESPACE  = _{ " " | NEWLINE}
+WHITESPACE  = _{ " " | "\t" | NEWLINE}
 COMMENT     = _{
     ("/*" ~ (!"*/" ~ ANY)* ~ "*/") |
     ("//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE)


### PR DESCRIPTION
Using a tab character inside a ZZ-program's source emits a parse error.

This commit modifies the pest-grammar to allow tab characters as
whitespace.