### PR TITLE
Fix empty input filename problem for GCC

### DIFF
--- a/src/abs.rs
+++ b/src/abs.rs
@@ -593,7 +593,7 @@ pub fn abs(md: &mut ast::Module, all_modules: &HashMap<Name, loader::Module>, ex
     let mut scope = Scope::default();
     scope.push();
 
-    let mut newimports = Vec::new();
+    let newimports = Vec::new();
     for import in &mut md.imports {
 
         let mut fqn  = abs_import(&md.name, &import, all_modules);

--- a/src/emitter_docs.rs
+++ b/src/emitter_docs.rs
@@ -149,7 +149,7 @@ self.module.name.0[1..].join("::")).unwrap();
     }
 
     pub fn emit_enum(&mut self, ast: &ast::Local) {
-        let names = match &ast.def {
+        let _names = match &ast.def {
             ast::Def::Enum{names} => (names),
             _ => unreachable!(),
         };
@@ -179,7 +179,7 @@ self.module.name.0[1..].join("::")).unwrap();
         for arg in args {
             sargs.insert(arg.name.clone(), format!("{}", arg.typed));
         }
-        let mut tpl = FunctionHtml {
+        let tpl = FunctionHtml {
             doc:  ast.doc.clone().replace("\n", "<br>"),
             name: Name::from(&ast.name).0.last().unwrap().clone(),
             ret:  ret.as_ref().map(|r|{

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -639,7 +639,7 @@ impl Stack {
     }
 
     fn drop_frame(&mut self, loc: &ast::Location, frame: usize) -> Result<Vec<Box<ast::Statement>>, Error> {
-        let mut r = Vec::new();
+        let r = Vec::new();
         for (name, storage) in &self.stack[frame].storage {
 
             //TODO also drop owned pointers some day

--- a/src/make.rs
+++ b/src/make.rs
@@ -105,18 +105,19 @@ impl Make {
         let features = config.features(variant);
 
         let mut cflags : Vec<String> =
-                std::env::var("TARGET_CFLAGS")
-                .or(std::env::var("CFLAGS"))
-                .unwrap_or("".to_string()).split(" ")
-                .map(|s|s.to_string()).collect();
+            match std::env::var("TARGET_CFLAGS").or(std::env::var("CFLAGS")) {
+                Err(_) => Vec::new(),
+                Ok(s) => s.split(" ").map(|s|s.to_string()).collect()
+            };
 
         let mut lflags : Vec<String> =
-                std::env::var("TARGET_LDFLAGS")
-                .or(std::env::var("TARGET_LFLAGS"))
-                .or(std::env::var("LDFLAGS"))
-                .or(std::env::var("LFLAGS"))
-                .unwrap_or("".to_string()).split(" ")
-                .map(|s|s.to_string()).collect();
+            match std::env::var("TARGET_LDFLAGS")
+                    .or(std::env::var("TARGET_LFLAGS"))
+                    .or(std::env::var("LDFLAGS"))
+                    .or(std::env::var("LFLAGS")) {
+                Err(_) => Vec::new(),
+                Ok(s) => s.split(" ").map(|s|s.to_string()).collect()
+            };
 
         let mut cc = std::env::var("TARGET_CC")
             .or(std::env::var("CC"))
@@ -366,7 +367,7 @@ impl Make {
                     .status()
                     .expect("failed to execute cc");
                 if !status.success() {
-                    error!("{} {}", self.cc, step.args.join(" "));
+                    error!("cc: [{}] args: [{}]", self.cc, step.args.join(" "));
                     ABORT.store(true, Ordering::Relaxed);
                 }
             }


### PR DESCRIPTION
Fix gcc builds that were confused into thinking the input filename was an empty string if CFLAGS or LDFLAGS were empty. Also try to make some warnings go away.